### PR TITLE
Specify `resolve.symlinks` option.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,8 @@
  *
  * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 const async = require('async');
 const bedrock = require('bedrock');
 const config = bedrock.config;
@@ -239,8 +241,8 @@ api.optimize = function(options, callback) {
 
 // build webpack resolve aliases from pseudo packages
 function _buildAliases(callback) {
-  async.mapSeries(bedrock.config.views.system.packages, (package, callback) => {
-    fs.readFile(package.manifest, (err, data) => {
+  async.mapSeries(bedrock.config.views.system.packages, (pkg, callback) => {
+    fs.readFile(pkg.manifest, (err, data) => {
       if(err) {
         return callback(err);
       }
@@ -248,7 +250,7 @@ function _buildAliases(callback) {
       callback(null, {
         resolve: {
           alias: {
-            [manifest.name]: package.path
+            [manifest.name]: pkg.path
           }
         }
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,8 @@ bedrock.events.on('bedrock-views.optimize.run', (options, callback) => {
             resolve: {
               modules: [
                 path.dirname(bedrock.config.views.system.paths.importAll)
-              ]
+              ],
+              symlinks: false
             }
           }
         ]

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,7 +111,7 @@ api.optimize = function(options, callback) {
   logger.info('webpack optimizer running...');
 
   const command = bedrock.config.cli.command;
-  const entry = ['babel-polyfill'].concat(options.main)
+  const entry = ['babel-polyfill'].concat(options.main);
   logger.info(`Optimizing: "${entry}" to: "${options.output}"`);
 
   const baseConfig = {


### PR DESCRIPTION
Allows symlinked modules to be processed properly.

@davidlehn I know you're familiar with this issue, will you confirm this fix?

This solution came from: https://github.com/babel/babel-loader/issues/149#issuecomment-312622067