### PR TITLE
Only define process.env.NODE_ENV in production.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # bedrock-webpack ChangeLog
 
+### Changed
+- Only define `process.env.NODE_ENV` when `--webpack-mode production` is used.
+  Allows use of frontend production only code.
+
 ## 3.2.0 - 2020-02-13
 
 ### Fixed

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,6 +227,18 @@ api.bundle = async (options = {}) => {
     webpackHmrEntry.push('webpack-hot-middleware/client');
   }
 
+  const webpackDefinePlugin = [];
+  const defines = {
+    // FIXME: are these needed?
+    'process.env.DEBUG': '"false"',
+    'process.env.BUILD': '"web"'
+  };
+  if(isProduction) {
+    // FIXME: are other modes needed?
+    defines['process.env.NODE_ENV'] = '"production"';
+  }
+  webpackDefinePlugin.push(new webpack.DefinePlugin(defines));
+
   // clean mode
   const webpackCleanPlugin = [];
   if(command.webpackClean === 'true') {
@@ -416,12 +428,7 @@ api.bundle = async (options = {}) => {
       ]
     },
     plugins: [
-      new webpack.DefinePlugin({
-        // FIXME: use mode flag?
-        'process.env.NODE_ENV': '"production"',
-        'process.env.DEBUG': '"false"',
-        'process.env.BUILD': '"web"'
-      }),
+      ...webpackDefinePlugin,
       ...webpackCleanPlugin,
       ...webpackMiniCssExtractPlugin,
       ...webpackOptimizeCssPlugin,


### PR DESCRIPTION
I'm unsure if there are any unintended side effects of this in other modules.