### PR TITLE
node-sass update

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -694,7 +694,7 @@ async function _buildOverrideConfigs({pkgs = {}}) {
   const webpackOverridesManifests = Object.keys(pkgs)
     .map(key => pkgs[key].manifest)
     .filter(manifest => manifest.bedrock && manifest.bedrock.webpack);
-  webpackOverridesManifests.map(({bedrock}) => {
+  webpackOverridesManifests.forEach(({bedrock}) => {
     const {webpack} = bedrock;
     Object.keys(webpack).forEach(pkgName => {
       // if the override contains manifest.webpack.resolve.alias

--- a/lib/index.js
+++ b/lib/index.js
@@ -701,21 +701,21 @@ async function _buildOverrideConfigs({pkgs = {}}) {
       const config = webpack[pkgName];
       if(config) {
         configs.push(config);
-      }
 
-      if((config.resolve || {}).alias) {
-        // specially resolve alias paths to full path
-        Object.keys(config.resolve.alias).forEach(alias => {
-          // TODO: check to see if we can get `path` from the pseudo package
-          // so we don't need to recompute here or assume top-level modules
+        if((config.resolve || {}).alias) {
+          // specially resolve alias paths to full path
+          Object.keys(config.resolve.alias).forEach(alias => {
+            // TODO: check to see if we can get `path` from the pseudo package
+            // so we don't need to recompute here or assume top-level modules
 
-          // resolve the relative path within a package to an absolute path
-          const aliasPath = path.resolve(
-            NODE_MODULES_DIR,
-            pkgName,
-            webpack[pkgName].resolve.alias[alias]);
-          config.resolve.alias[alias] = aliasPath;
-        });
+            // resolve the relative path within a package to an absolute path
+            const aliasPath = path.resolve(
+              NODE_MODULES_DIR,
+              pkgName,
+              webpack[pkgName].resolve.alias[alias]);
+            config.resolve.alias[alias] = aliasPath;
+          });
+        }
       }
     });
   });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "less": "^3.10.3",
     "less-loader": "^5.0.0",
     "mini-css-extract-plugin": "^0.9.0",
-    "node-sass": "^4.13.1",
+    "node-sass": "^5.0.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "regenerator-runtime": "^0.13.2",
     "sass-loader": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-sass": "^5.0.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "regenerator-runtime": "^0.13.2",
-    "sass-loader": "^8.0.2",
+    "sass-loader": "^10.1.1",
     "stats-webpack-plugin": "^0.7.0",
     "stylus": "^0.54.7",
     "stylus-loader": "^3.0.2",


### PR DESCRIPTION
nodes-sass@5 release notes don't indicate any breaking changes of concern: https://github.com/sass/node-sass/releases

### Purpose
This addresses a minor pain point that slows down our docker builds because on Alpine the node-sass stuff has to be built from source which involves additional build deps as well as a time consuming build process.  node-sass@5 includes pre-built binaries for node14-alpine.

### Testing:
I've tested this with top level app, and it works properly.