### PR TITLE
Update deps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   - Node.js polyfills are now disabled by default.
   - Assets are put into a single directory rather than `js`, `css`,
     and `images`. (This may change back in the future if possible.)
+  - HTML and CSS resource paths (such as images) may need to be
+    relative to the source files rather than absolute. The tools can
+    then copy resources and adjust paths as needed in the output.
 - Upgrade other dependencies.
 - Improved some webpack error logging.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Removed
 - `bedrock-webpack.terser.config` setting.
+- babel plugins are now handled by `@babel/preset-env`:
+  - `@babel/plugin-syntax-dynamic-import`
+  - `@babel/plugin-proposal-object-rest-spread`
 
 ## 3.6.0 - 2021-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # bedrock-webpack ChangeLog
 
+## 4.0.0 - 2022-xx-xx
+
+### Changed
+- **BREAKING**: Upgrade to `webpack@5`.
+  - Custom webpack configuration may need to be adjusted.
+  - Node.js polyfills are now disabled by default.
+  - Assets are put into a single directory rather than `js`, `css`,
+    and `images`. (This may change back in the future if possible.)
+- Upgrade other dependencies.
+
+### Removed
+- `bedrock-webpack.terser.config` setting.
+
 ## 3.6.0 - 2021-01-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Assets are put into a single directory rather than `js`, `css`,
     and `images`. (This may change back in the future if possible.)
 - Upgrade other dependencies.
+- Improved some webpack error logging.
 
 ### Removed
 - `bedrock-webpack.terser.config` setting.

--- a/lib/config.js
+++ b/lib/config.js
@@ -44,7 +44,3 @@ cc('bedrock-webpack.polyfillEntry', () => [
 // babel-loader cache
 cc('bedrock-webpack.babel-loader.cache', () => path.join(
   config.paths.cache, 'bedrock-webpack', 'babel-loader'));
-
-// terser cache
-cc('bedrock-webpack.terser.cache', () => path.join(
-  config.paths.cache, 'bedrock-webpack', 'terser'));

--- a/lib/index.js
+++ b/lib/index.js
@@ -349,13 +349,6 @@ api.bundle = async (options = {}) => {
                     debug: command.webpackBabelDebug === 'true'
                   }
                 ]
-              ],
-              plugins: [
-                require.resolve('@babel/plugin-syntax-dynamic-import'),
-                [
-                  require.resolve('@babel/plugin-proposal-object-rest-spread'),
-                  {useBuiltIns: true}
-                ]
               ]
             }
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const filesize = require('file-size');
 const path = require('path');
 const util = require('util');
 const webpack = require('webpack');
-const webpackMerge = require('webpack-merge');
+const {merge: webpackMerge} = require('webpack-merge');
 const {BedrockError} = bedrock.util;
 const {CleanWebpackPlugin} = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -267,12 +267,12 @@ api.bundle = async (options = {}) => {
   if(command.webpackExtractCss === 'true') {
     webpackMiniCssExtractPlugin.push(new MiniCssExtractPlugin({
       //filename: path.join(paths.local, 'css', '[name].css')
-      filename: '../css/[name].css'
+      filename: '[name].css'
     }));
     miniCssExtractPluginLoader.push({
       loader: MiniCssExtractPlugin.loader,
       options: {
-        //publicPath: '../css/',
+        //publicPath: '.',
         /*
         publicPath: (resourcePath, context) => {
           console.log('PP', {resourcePath, context,
@@ -412,6 +412,8 @@ api.bundle = async (options = {}) => {
             prettify: !isProduction
           }
         },
+        /*
+        // FIXME: fix or remove due to webpack v5 path issues
         {
           test: /\.(woff|woff2|eot|ttf|otf|svg)$/,
           issuer: /\.(css|less|scss|styl(us)?)$/,
@@ -436,7 +438,8 @@ api.bundle = async (options = {}) => {
               outputPath: '../images'
             }
           }]
-        },
+        }
+        */
       ]
     },
     plugins: [
@@ -448,16 +451,7 @@ api.bundle = async (options = {}) => {
       ...webpackProgressPlugin,
       ...webpackHmrPlugin
     ],
-    profile: command.webpackProfile === 'true',
-    node: {
-      // FIXME: these disable polyfills globally
-      'base64-js': false,
-      Buffer: false,
-      crypto: false,
-      ieee754: false,
-      process: false,
-      setImmediate: false
-    }
+    profile: command.webpackProfile === 'true'
   };
 
   const aliasConfig = {
@@ -487,9 +481,7 @@ api.bundle = async (options = {}) => {
   const minimizerConfig = [];
   if(command.webpackOptimizeJs === 'true' || isProduction) {
     const terserOptions = {
-      cache: config['bedrock-webpack']['terser'].cache,
       parallel: true,
-      sourceMap: true,
       terserOptions: {}
     };
     if(command.webpackJsMangle !== 'default') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -563,7 +563,10 @@ api.bundle = async (options = {}) => {
   function webpackDone(err, {msg, stats}) {
     buildCount++;
     if(err) {
-      logger.error('error', err.stack || err);
+      const s = util.inspect(err, {
+        depth: null, colors: true
+      });
+      logger.error(`error:\n${s}\n`);
       if(err.details) {
         logger.error('error details', err.details);
       }
@@ -573,7 +576,9 @@ api.bundle = async (options = {}) => {
     const info = stats.toJson();
 
     if(stats.hasErrors()) {
-      const s = info.errors.toString();
+      const s = util.inspect(info.errors, {
+        depth: null, colors: true
+      });
       logger.error(`errors:\n${s}\n`);
       err = new BedrockError(
         'webpack error',

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-webpack",
   "dependencies": {
     "@babel/core": "^7.16.12",
-    "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.16.11",
     "app-root-path": "^3.0.0",
     "babel-loader": "^8.2.3",

--- a/package.json
+++ b/package.json
@@ -25,38 +25,38 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-webpack",
   "dependencies": {
-    "@babel/core": "^7.8.3",
+    "@babel/core": "^7.16.12",
     "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-    "@babel/preset-env": "^7.8.3",
+    "@babel/preset-env": "^7.16.11",
     "app-root-path": "^3.0.0",
-    "babel-loader": "^8.0.5",
-    "clean-webpack-plugin": "^3.0.0",
-    "core-js": "^3.6.4",
-    "css-loader": "^3.4.2",
-    "file-loader": "^5.0.2",
+    "babel-loader": "^8.2.3",
+    "clean-webpack-plugin": "^4.0.0",
+    "core-js": "^3.20.3",
+    "css-loader": "^6.5.1",
+    "file-loader": "^6.2.0",
     "file-size": "^1.0.0",
-    "less": "^3.10.3",
-    "less-loader": "^5.0.0",
-    "mini-css-extract-plugin": "^0.9.0",
-    "node-sass": "^5.0.0",
-    "optimize-css-assets-webpack-plugin": "^5.0.1",
-    "regenerator-runtime": "^0.13.2",
-    "sass-loader": "^10.1.1",
+    "less": "^4.1.2",
+    "less-loader": "^10.2.0",
+    "mini-css-extract-plugin": "^2.5.2",
+    "node-sass": "^7.0.1",
+    "optimize-css-assets-webpack-plugin": "^6.0.1",
+    "regenerator-runtime": "^0.13.9",
+    "sass-loader": "^12.4.0",
     "stats-webpack-plugin": "^0.7.0",
-    "stylus": "^0.54.7",
-    "stylus-loader": "^3.0.2",
-    "terser-webpack-plugin": "^2.3.2",
-    "vue-loader": "^15.8.3",
-    "vue-style-loader": "^4.1.0",
-    "vue-template-compiler": "^2.6.11",
-    "webpack": "^4.41.5",
-    "webpack-hot-middleware": "^2.25.0",
-    "webpack-merge": "^4.2.2"
+    "stylus": "^0.56.0",
+    "stylus-loader": "^6.2.0",
+    "terser-webpack-plugin": "^5.3.0",
+    "vue-loader": "^15.9.8",
+    "vue-style-loader": "^4.1.3",
+    "vue-template-compiler": "^2.6.14",
+    "webpack": "^5.67.0",
+    "webpack-hot-middleware": "^2.25.1",
+    "webpack-merge": "^5.8.0"
   },
   "peerDependencies": {
-    "bedrock": "1.12.1 - 3.x",
-    "bedrock-views": "^7.0.0"
+    "bedrock": "^4.4.3",
+    "bedrock-views": "^7.1.0"
   },
   "directories": {
     "lib": "./lib"
@@ -65,7 +65,7 @@
     "node": ">=10.13"
   },
   "devDependencies": {
-    "eslint": "^7.18.0",
-    "eslint-config-digitalbazaar": "^2.1.0"
+    "eslint": "^8.7.0",
+    "eslint-config-digitalbazaar": "^2.8.0"
   }
 }


### PR DESCRIPTION
The big change here is upgrading to `webpack@5`.  Along with it all other dependencies were upgraded.

Due to some webpackisms, the former code to split files out into js/, css/, and images/ was failing to work in production mode.  That was just disabled and the tools now put everything in one directory.  It's not as pretty (IMHO), but should work fine for almost every use case.

Note this is similar to @aljones15 work in https://github.com/digitalbazaar/bedrock-webpack/tree/use-webpack-v5.