### PR TITLE
Add config option templates.index, set to current default path, & use…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-webpack ChangeLog
 
+## 9.1.3
+
+### Added
+- A new config option `config['bedrock-webpack'].templates.index` for alternative `index.html` templates.
+
 ## 9.0.3 - 2023-03-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-webpack ChangeLog
 
-## 9.1.3
+## 9.1.0 - 2023-xx-xx
 
 ### Added
 - A new config option `config['bedrock-webpack'].templates.index` for alternative `index.html` templates.

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,6 +14,11 @@ config['bedrock-webpack'] = {};
 // configs to be merged with webpack-merge into the base config
 config['bedrock-webpack'].configs = [];
 
+// the location of the index template can be specified here
+config['bedrock-webpack'].templates = {
+  index: path.join(__dirname, '..', 'templates', 'index.html')
+};
+
 // default main output file location
 cc('bedrock-webpack.out', () => path.join(
   config.paths.cache, 'bedrock-webpack', 'main.min.js'));

--- a/lib/index.js
+++ b/lib/index.js
@@ -242,7 +242,7 @@ export async function bundle(options = {}) {
   // html webpack plugin
   const webpackHtmlPlugin = [];
   webpackHtmlPlugin.push(new HtmlWebpackPlugin({
-    template: path.join(__dirname, '..', 'templates', 'index.html')
+    template: config['bedrock-webpack'].templates.index
   }));
   // set entry
   const entry = [


### PR DESCRIPTION
Features:

1. Add a new config option `templates.index`
2. Set `templates.index` to the current template
3. Add minor changelog entry


Tests:
1. continues to work even if a custom template is not set
2. works with a custom template
3. throws if the custom template path does not exist