### PR TITLE
Update license section in README to latest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 TAGS
 node_modules
 npm-debug.log
+package-lock.json

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -2,6 +2,6 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Contact: Digital Bazaar, Inc. <support@digitalbazaar.com>
 
 Files: *.md .gitignore .npmrc package.json test/.npmrc test/mocha/.eslintrc
-    test/package.json .editorconfig .github/* test/static/*.html
+    test/package.json .editorconfig .github/* templates/*
 Copyright: 2012-2024 Digital Bazaar, Inc.
 License: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ if(typeof MY_JSON !== 'undefined') {
 
 [Apache License, Version 2.0](LICENSE) Copyright 2017-2024 Digital Bazaar, Inc.
 
-Additional Bedrock libraries are available for non-commercial use such as
-self-study, research, personal projects, or for evaluation purposes. See the
+Other Bedrock libraries are available under a non-commercial license for uses
+such as self-study, research, personal projects, or for evaluation purposes.
+See the
 [Bedrock Non-Commercial License v1.0](https://github.com/digitalbazaar/bedrock/blob/main/LICENSES/LicenseRef-Bedrock-NC-1.0.txt)
 for details.
 


### PR DESCRIPTION
- Add `templates/*` to dep5 file to license.
- Update README license section to latest.
