### PR TITLE
Upgrade Webpack to v5.90.0+.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-webpack ChangeLog
 
+## 10.1.0 - 2024-09-dd
+
+### Fixed
+- Upgraded Webpack to v5.90.0+ to support `unmanagedPaths` in configurations.
+
 ## 10.0.0 - 2024-03-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "terser-webpack-plugin": "^5.3.1",
     "vue": "^3.2.36",
     "vue-loader": "^17.0.0",
-    "webpack": "^5.72.0",
+    "webpack": "^5.90.0",
     "webpack-hot-middleware": "^2.25.1",
     "webpack-merge": "^5.8.0"
   },


### PR DESCRIPTION
This fixes an issue for fresh installations that may still be using versions
of Webpack earlier than v5.90.0 (when `unmanagedPaths` was added).

This repo began using `unmanagedPaths` in Webpack configurations in this PR:
https://github.com/digitalbazaar/bedrock-webpack/commit/2abcdd05f62e1839e8723d91bec3be81497b1f6c#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1R434
