### PR TITLE
Replace hash with contenthash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-webpack ChangeLog
 
+## 11.6.2 - 2026-06-dd
+
+### Fixed
+- Replace deprecated [hash] with [contenthash] in webpack output filename.
+
 ## 11.6.1 - 2026-06-04
 
 ### Fixed

--- a/lib/index.js
+++ b/lib/index.js
@@ -296,7 +296,7 @@ export async function bundle(options = {}) {
     output: {
       path: path.join(paths.local, 'js'),
       publicPath: path.join(paths.public, 'js/'),
-      filename: '[name].[hash].js',
+      filename: '[name].[contenthash].js',
       ...webpackCleanOptions
     },
     resolve: {


### PR DESCRIPTION
**_Fix: Replace deprecated [hash] with [contenthash] in webpack output filename_**

---

#### Summary

Webpack 5 deprecated the [hash] template variable for output filenames. It emits this deprecation warning when the variable is encountered:

[DEP_WEBPACK_TEMPLATE_PATH_PLUGIN_REPLACE_PATH_VARIABLES_HASH] DeprecationWarning:
[hash] is now [fullhash] (also consider using [chunkhash] or [contenthash])

The direct rename is [hash] → [fullhash], but webpack's [contenthash] might be the better choice for output filenames because it only changes when that file's content changes — giving downstream consumers better cache behavior. [fullhash] changes on every build regardless of content.

This is a patch update:
- Fixes a deprecation warning emitted by webpack 5
- Does not alter the public API of this package
- Produces the same filename structure ([name].<hash>.js), just with a more stable hash algorithm
- No consumer code changes required